### PR TITLE
Fixes deepethogram/#74

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=['h5py',
                       'numpy',
-                      'opencv-python']
+                      'opencv-python-headless']
 )


### PR DESCRIPTION
Use `opencv-python-headless` instead of `opencv-python`

See: https://github.com/jbohnslav/deepethogram/issues/74